### PR TITLE
fix(deps): add packaging requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ release_status = "Development Status :: 4 - Beta"
 dependencies = [
     "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
     "proto-plus >= 1.4.0",
+    "packaging >= 14.3"
 ]
 
 package_root = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ release_status = "Development Status :: 4 - Beta"
 dependencies = [
     "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
     "proto-plus >= 1.4.0",
-    "packaging >= 14.3"
+    "packaging >= 14.3",
 ]
 
 package_root = os.path.abspath(os.path.dirname(__file__))

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -6,4 +6,4 @@
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
 google-api-core==1.22.2
-proto-plus==1.4.0
+proto-plus==1.4.0packaging==14.3

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -6,4 +6,5 @@
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
 google-api-core==1.22.2
-proto-plus==1.4.0packaging==14.3
+proto-plus==1.4.0
+packaging==14.3


### PR DESCRIPTION
Add packaging requirement. packaging.version
              is used for a version comparison in transports/base.py and is needed after the upgrade to gapic-generator-python 0.46.3