### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,14 +1,16 @@
 {
-  "name": "phishingprotection",
-  "name_pretty": "Phishing Protection",
-  "product_documentation": "https://cloud.google.com/phishing-protection/docs/",
-  "client_documentation": "https://googleapis.dev/python/phishingprotection/latest",
-  "issue_tracker": "",
-  "release_level": "beta",
-  "language": "python",
-  "library_type": "GAPIC_AUTO",
-  "repo": "googleapis/python-phishingprotection",
-  "distribution_name": "google-cloud-phishing-protection",
-  "api_id": "phishingprotection.googleapis.com",
-  "requires_billing": true
+    "name": "phishingprotection",
+    "name_pretty": "Phishing Protection",
+    "product_documentation": "https://cloud.google.com/phishing-protection/docs/",
+    "client_documentation": "https://googleapis.dev/python/phishingprotection/latest",
+    "issue_tracker": "",
+    "release_level": "beta",
+    "language": "python",
+    "library_type": "GAPIC_AUTO",
+    "repo": "googleapis/python-phishingprotection",
+    "distribution_name": "google-cloud-phishing-protection",
+    "api_id": "phishingprotection.googleapis.com",
+    "requires_billing": true,
+    "default_version": "",
+    "codeowner_team": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,6 +11,6 @@
     "distribution_name": "google-cloud-phishing-protection",
     "api_id": "phishingprotection.googleapis.com",
     "requires_billing": true,
-    "default_version": "",
+    "default_version": "v1beta1",
     "codeowner_team": ""
 }


### PR DESCRIPTION
By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114