### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "phishingprotection",
     "name_pretty": "Phishing Protection",
     "product_documentation": "https://cloud.google.com/phishing-protection/docs/",
-    "client_documentation": "https://googleapis.dev/python/phishingprotection/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/phishingprotection/latest",
     "issue_tracker": "",
     "release_level": "beta",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Python Client for Phishing Protection API
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-phishing-protection.svg
    :target: https://pypi.org/project/google-cloud-phishing-protection/
 
-.. _Client Library Documentation: https://googleapis.dev/python/phishingprotection/latest/
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/phishingprotection/latest/
 .. _Product Documentation:  https://cloud.google.com/phishing-protection
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.