### PR TITLE
chore: Prepare for mono repository migration

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -38,13 +38,6 @@ for library in s.get_staging_dirs(default_version):
     s.move([library], excludes=["**/gapic_version.py"])
 s.remove_staging_dirs()
 
-# This replacement will no longer be required once this repo is migrated to google-cloud-python
-s.replace(
-    "setup.py",
-    "https://github.com/googleapis/python-phishing-protection",
-    "https://github.com/googleapis/python-phishingprotection",
-)
-
 # ----------------------------------------------------------------------------
 # Add templated files
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Remove replacement in owlbot.py which will be obsolete in the monorepo as the reason for the customization was due to the discrepancy between the package name `google-cloud-phishing-protection` and the repository name `python-phishingprotection` (no hyphen). In the monorepo, we will have package `google-cloud-phishing-protection` which is predictable.